### PR TITLE
Allows annotations for services to enable cloud provided load balancers

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 #This is the chart version.
-version: 0.5.0
+version: 0.5.1
 
 #This is application version.
 appVersion: "v1.18.1"

--- a/charts/chatwoot/templates/web-service.yaml
+++ b/charts/chatwoot/templates/web-service.yaml
@@ -5,7 +5,10 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "rails.labels" . | nindent 4}}
-
+  {{- with .Values.services.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ports:
     - name: {{ .Values.services.name | quote}}

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -17,6 +17,11 @@ services:
   internlPort: 3000
   targetPort: 3000
   type: LoadBalancer
+  annotations: {}
+    # For example
+    #  service.beta.kubernetes.io/aws-load-balancer-type: external
+    #  service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    #  service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -65,7 +65,7 @@ ingress:
           pathType: Prefix
           backend:
             service:
-              name: chatwoot-service
+              name: chatwoot
               port:
                 number: 3000
   tls: []


### PR DESCRIPTION
Allows annotations in chatwoot service for cloud service provider required fields, for example ```cloud.google.com/neg: '{"ingress": true}'```  in the values.yaml file.



Signed-off-by: thundersparkf <devagastya0@gmail.com>