### PR TITLE
Increment app version to v1.19.0

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 0.6.0
+version: 0.6.1
 
 # This is the application version.
-appVersion: "v1.18.2"
+appVersion: "v1.19.0"

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -4,13 +4,13 @@
 # Overrides the image tag whose default is the chart appVersion.
 image:
   repository: chatwoot/chatwoot
-  tag: v1.18.2
+  tag: v1.19.0
   pullPolicy: IfNotPresent
 
 web:
   replica: 1
 worker:
-  replica: 1
+  replica: 2
 
 services:
   name: chatwoot


### PR DESCRIPTION
- Update app version to point to latest chatwoot release v1.19.0