### PR TITLE
feat: use pg_ready for k8s migration job init-check

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 0.6.3
+version: 0.6.4
 
 # This is the application version.
 appVersion: "v1.19.0"

--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -19,10 +19,21 @@ spec:
       restartPolicy: Never
       initContainers:
       - name: init-postgres
-        image: busybox:1.28
-        command: ["sh", "-c",  "until nslookup {{ template "chatwoot.postgresql.host" . }} ; do echo waiting for {{ template "chatwoot.postgresql.host" . }}; sleep 2; done;"]
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/bin/sh"]
+        args:
+          - -c
+          - >-
+            PG_READY="pg_isready -h {{ template "chatwoot.postgresql.host" . }} -p {{ template "chatwoot.postgresql.port" . }}";
+            until $PG_READY;
+            do
+              sleep 2;
+            done;
+            echo "Database ready to accept connections."  ;
       - name: init-redis
         image: busybox:1.28
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["sh", "-c", "until nslookup {{ template "chatwoot.redis.host" . }} ; do echo waiting for {{ template "chatwoot.redis.host" . }} ; sleep 2; done;"]
       containers:
       - name: "db-migrate-job"


### PR DESCRIPTION
`nslookup` of DB hostname was used as DB init check for migration job. This was causing the migration job container to fail multiple times. NSLOOKUP being successful does not equate to DB is ready to accept connections.

This PR changed that to use the `pg_ready` tool which is a much more reliable metric to assess DB ready status.

Fixes #32 