### PR TITLE
feat: update charts to chatwoot v1.21.1

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 0.6.6
+version: 0.6.7
 
 # This is the application version.
-appVersion: "v1.20.0"
+appVersion: "v1.21.1"

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -4,7 +4,7 @@
 # Overrides the image tag whose default is the chart appVersion.
 image:
   repository: chatwoot/chatwoot
-  tag: v1.20.0
+  tag: v1.21.1
   pullPolicy: IfNotPresent
 
 web:


### PR DESCRIPTION

## Description
* Update charts to chatwoot `v1.21.1`
* https://github.com/chatwoot/chatwoot/releases/tag/v1.21.1


## Type of change
- [x] Chore (Update Chatwoot version) 

## How Has This Been Tested?
- Tested installation against a fresh k8s cluster.
- Tested upgrade against a k8s cluster running Chatwoot `v1.20.0`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
