### PR TITLE
feat: update chart to v1.22.0

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 0.6.7
+version: 0.6.8
 
 # This is the application version.
-appVersion: "v1.21.1"
+appVersion: "v1.22.0"

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -4,7 +4,7 @@
 # Overrides the image tag whose default is the chart appVersion.
 image:
   repository: chatwoot/chatwoot
-  tag: v1.21.1
+  tag: v1.22.0
   pullPolicy: IfNotPresent
 
 web:


### PR DESCRIPTION
## Description
* Update charts to chatwoot `v1.22.0`
* https://github.com/chatwoot/chatwoot/releases/tag/v1.22.0


## Type of change
- [x] Chore (Update Chatwoot version) 

## How Has This Been Tested?
- [x] Tested installation against a fresh k8s cluster.
- [x] Tested upgrade against a k8s cluster running Chatwoot `v1.21.1`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
