### PR TITLE
feat: add autoscaling to web and worker pods

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 0.8.9
+version: 0.9.0
 
 # This is the application version.
 appVersion: "v2.7.0"

--- a/charts/chatwoot/README.md
+++ b/charts/chatwoot/README.md
@@ -179,7 +179,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | services.annotations | object | `{}` |  |
-| services.internlPort | int | `3000` |  |
+| services.internalPort | int | `3000` |  |
 | services.name | string | `"chatwoot"` |  |
 | services.targetPort | int | `3000` |  |
 | services.type | string | `"LoadBalancer"` |  |

--- a/charts/chatwoot/README.md
+++ b/charts/chatwoot/README.md
@@ -141,15 +141,26 @@ The command removes all the Kubernetes components associated with the chart and 
 | `env.TWITTER_CONSUMER_SECRET`       | For twitter channel                                                  | `""`                                                       |
 | `env.TWITTER_ENVIRONMENT`           | For twitter channel                                                  | `""`                                                       |
 
+### Autoscaling
+
+| Name                                | Type                                                                 | Default Value                                              |
+| ----------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `web.hpa.enabled`                   | Horizontal Pod Autoscaling for Chatwoot web                          | `false`                                                    |
+| `web.hpa.cputhreshold`              | CPU threshold for Chatwoot web                                       | `80`                                                       |
+| `web.hpa.minpods`                   | Minimum number of pods for Chatwoot web                              | `1`                                                        |
+| `web.hpa.maxpods`                   | Maximum number of pods for Chatwoot web                              | `10`                                                       |
+| `web.replicaCount`                  | No of web pods if hpa is not enabled                                 | `1`                                                        |
+| `worker.hpa.enabled`                | Horizontal Pod Autoscaling for Chatwoot worker                       | `false`                                                    |
+| `worker.hpa.cputhreshold`           | CPU threshold for Chatwoot worker                                    | `80`                                                       |
+| `worker.hpa.minpods`                | Minimum number of pods for Chatwoot worker                           | `2`                                                        |
+| `worker.hpa.maxpods`                | Maximum number of pods for Chatwoot worker                           | `10`                                                       |
+| `worker.replicaCount`               | No of worker pods if hpa is not enabled                              | `1`                                                        |
+
 ### Other Parameters
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `100` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | fullnameOverride | string | `""` |  |
 | hooks.affinity | object | `{}` |  |
 | hooks.migrate.env | list | `[]` |  |
@@ -184,9 +195,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | services.targetPort | int | `3000` |  |
 | services.type | string | `"LoadBalancer"` |  |
 | tolerations | list | `[]` |  |
-| web.replica | int | `1` |  |
-| worker.replica | int | `1` |  |
-
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -214,9 +222,31 @@ PostgreSQL is installed along with the chart if you choose the default setup. To
 
 Redis is installed along with the chart if you choose the default setup. To use an external Redis DB, please set `redis.enabled` to `false` and set the variables under the Redis section above.
 
+# Autoscaling
+
+To enable horizontal pod autoscaling, set `web.hpa.enabled` and `worker.hpa.enabled` to `true`. Also make sure to uncomment the values under, `resources.limits` and `resources.requests`. This assumes your k8s cluster is already having a metrics-server. If not, deploy metrics-server with the following command.
+
+```
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+```
 
 ## Upgrading
 
+Do `helm repo update` and check the version of charts that is going to be installed. Helm charts follows semantic versioning and so if the MAJOR version is different from your installed version, there might be breaking changes. Please refer to the changelog before upgrading.
+
+```
+# update helm repositories
+helm repo update
+# list your current installed version
+helm list
+# show the latest version of charts that is going to be installed
+helm search repo chatwoot
+```
+
+```
+#if it is major version update, refer to the changelog before proceeding
+helm upgrade chatwoot chatwoot/chatwoot -f <your-custom-values>.yaml
+```
 ## To 0.8.x
 
 Move from Kubernetes ConfigMap to Kubernetes Secrets for environment variables. This is not a breaking change.

--- a/charts/chatwoot/README.md
+++ b/charts/chatwoot/README.md
@@ -247,11 +247,20 @@ helm search repo chatwoot
 #if it is major version update, refer to the changelog before proceeding
 helm upgrade chatwoot chatwoot/chatwoot -f <your-custom-values>.yaml
 ```
-## To 0.8.x
+
+### To 0.9.x
+
+This release adds support for horizontal pod autoscaling(hpa) for chatwoot-web and chatwoot-worker deployments.
+Also, this changes the default redis replica count to `1`. The `Values.web.replicas` and `Values.worker. replicas` parameters
+where renamed to `Values.web.replicaCount` and `Values.worker.replicaCount` respectively. Also `services.internlPort` was renamed
+to `services.internalPort`.
+
+Please make the necessary changes in your custom values file if needed.
+### To 0.8.x
 
 Move from Kubernetes ConfigMap to Kubernetes Secrets for environment variables. This is not a breaking change.
 
-## To 0.6.x
+### To 0.6.x
 
 Existing labels were causing issues with `helm upgrade`. `0.6.x` introduces breaking changes related to selector 
 labels used for deployments. Please delete your helm release and recreate it. Deleting your helm release will

--- a/charts/chatwoot/README.md
+++ b/charts/chatwoot/README.md
@@ -256,6 +256,7 @@ where renamed to `Values.web.replicaCount` and `Values.worker.replicaCount` resp
 to `services.internalPort`.
 
 Please make the necessary changes in your custom values file if needed.
+
 ### To 0.8.x
 
 Move from Kubernetes ConfigMap to Kubernetes Secrets for environment variables. This is not a breaking change.

--- a/charts/chatwoot/templates/web-deployment.yaml
+++ b/charts/chatwoot/templates/web-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - rails
             - s
             - -p
-            - {{ .Values.services.internlPort | quote}}
+            - {{ .Values.services.internalPort | quote}}
             - -b
             - 0.0.0.0
           command:
@@ -66,7 +66,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           name: {{ .Chart.Name }}-web
           ports:
-            - containerPort: {{ int .Values.services.internlPort }}
+            - containerPort: {{ int .Values.services.internalPort }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.resources }}
           resources:

--- a/charts/chatwoot/templates/web-deployment.yaml
+++ b/charts/chatwoot/templates/web-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: {{ int .Values.web.replica }}
+  replicas: {{ int .Values.web.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "chatwoot.fullname" . }}

--- a/charts/chatwoot/templates/web-hpa.yaml
+++ b/charts/chatwoot/templates/web-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.web.hpa.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "chatwoot.fullname" . }}-web
@@ -15,5 +15,11 @@ spec:
     name: {{ template "chatwoot.fullname" . }}-web
   minReplicas: {{ .Values.web.hpa.minpods }}
   maxReplicas: {{ .Values.web.hpa.maxpods }}
-  targetCPUUtilizationPercentage: {{ .Values.web.hpa.cputhreshold }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.web.hpa.cputhreshold }}
   {{- end }}

--- a/charts/chatwoot/templates/web-hpa.yaml
+++ b/charts/chatwoot/templates/web-hpa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.web.hpa.enabled -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "chatwoot.fullname" . }}-web
+  labels:
+    app: {{ template "chatwoot.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: {{ template "chatwoot.fullname" . }}-web
+  minReplicas: {{ .Values.web.hpa.minpods }}
+  maxReplicas: {{ .Values.web.hpa.maxpods }}
+  targetCPUUtilizationPercentage: {{ .Values.web.hpa.cputhreshold }}
+  {{- end }}

--- a/charts/chatwoot/templates/web-service.yaml
+++ b/charts/chatwoot/templates/web-service.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   ports:
     - name: {{ .Values.services.name | quote}}
-      port: {{ int .Values.services.internlPort }}
+      port: {{ int .Values.services.internalPort }}
       targetPort: {{ int .Values.services.targetPort }}
   type: {{ .Values.services.type }}
   selector:

--- a/charts/chatwoot/templates/worker-deployment.yaml
+++ b/charts/chatwoot/templates/worker-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: {{ int .Values.worker.replica }}
+  replicas: {{ int .Values.worker.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "chatwoot.fullname" . }}
@@ -68,4 +68,3 @@ spec:
       serviceAccountName: {{ include "chatwoot.serviceAccountName" . }}
 
 status: {}
-

--- a/charts/chatwoot/templates/worker-hpa.yaml
+++ b/charts/chatwoot/templates/worker-hpa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.worker.hpa.enabled -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "chatwoot.fullname" . }}-worker
+  labels:
+    app: {{ template "chatwoot.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    apiVersion: apps/v1
+    name: {{ template "chatwoot.fullname" . }}-worker
+  minReplicas: {{ .Values.worker.hpa.minpods }}
+  maxReplicas: {{ .Values.worker.hpa.maxpods }}
+  targetCPUUtilizationPercentage: {{ .Values.worker.hpa.cputhreshold }}
+  {{- end }}

--- a/charts/chatwoot/templates/worker-hpa.yaml
+++ b/charts/chatwoot/templates/worker-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.worker.hpa.enabled -}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "chatwoot.fullname" . }}-worker
@@ -15,5 +15,11 @@ spec:
     name: {{ template "chatwoot.fullname" . }}-worker
   minReplicas: {{ .Values.worker.hpa.minpods }}
   maxReplicas: {{ .Values.worker.hpa.maxpods }}
-  targetCPUUtilizationPercentage: {{ .Values.worker.hpa.cputhreshold }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.worker.hpa.cputhreshold }}
   {{- end }}

--- a/charts/chatwoot/values.ci.yaml
+++ b/charts/chatwoot/values.ci.yaml
@@ -1,7 +1,11 @@
 web:
-  replica: 1
+  hpa:
+    enabled: true
+  replicaCount: 1
 worker:
-  replica: 1
+  hpa:
+    enabled: true
+  replicaCount: 1
 
 redis:
   replica:

--- a/charts/chatwoot/values.ci.yaml
+++ b/charts/chatwoot/values.ci.yaml
@@ -1,12 +1,27 @@
 web:
   hpa:
     enabled: true
+    cputhreshold: 80
+    minpods: 1
+    maxpods: 10
   replicaCount: 1
 worker:
   hpa:
+    cputhreshold: 80
+    minpods: 1
+    maxpods: 10
     enabled: true
   replicaCount: 1
 
 redis:
-  replica:
-    replicaCount: 1
+  architecture: standalone
+  # replica:
+  #   replicaCount: 1
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -23,7 +23,7 @@ worker:
     enabled: false
     cputhreshold: 75
     minpods: 2
-    maxpods: 10  
+    maxpods: 10
   replicaCount: 2
 
 services:

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -9,22 +9,26 @@ image:
 
 web:
   hpa:
+     # set this to true to enable horizontal pod autoscaling
+     # uncomment values.resources section if hpa is enabled
     enabled: false
-    cputhreshold: 60
-    minpods: 2
+    cputhreshold: 75
+    minpods: 1
     maxpods: 10
   replicaCount: 1
 worker:
   hpa:
+    # set this to true to enable horizontal pod autoscaling
+    # uncomment values.resources section if hpa is enabled
     enabled: false
-    cputhreshold: 60
-    minpods: 4
+    cputhreshold: 75
+    minpods: 2
     maxpods: 10  
   replicaCount: 2
 
 services:
   name: chatwoot
-  internlPort: 3000
+  internalPort: 3000
   targetPort: 3000
   type: LoadBalancer
   annotations: {}
@@ -92,11 +96,11 @@ resources: {}
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
+  #   cpu: 500m
+  #   memory: 512Mi
   # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  #   cpu: 250m
+  #   memory: 256Mi
 
 autoscaling:
   enabled: false

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -8,9 +8,19 @@ image:
   pullPolicy: IfNotPresent
 
 web:
-  replica: 1
+  hpa:
+    enabled: false
+    cputhreshold: 60
+    minpods: 2
+    maxpods: 10
+  replicaCount: 1
 worker:
-  replica: 2
+  hpa:
+    enabled: false
+    cputhreshold: 60
+    minpods: 4
+    maxpods: 10  
+  replicaCount: 2
 
 services:
   name: chatwoot

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -142,7 +142,7 @@ redis:
       enabled: true
       # If change pvc size redis.master.persistence.size: 20Gi
   replica:
-    replicaCount: 1 
+    replicaCount: 1
 
 # Provide affinity for hooks if needed
 hooks:

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -102,13 +102,6 @@ resources: {}
   #   cpu: 250m
   #   memory: 256Mi
 
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
-
 nodeSelector: {}
 
 tolerations: []

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -141,6 +141,8 @@ redis:
     persistence:
       enabled: true
       # If change pvc size redis.master.persistence.size: 20Gi
+  replica:
+    replicaCount: 1 
 
 # Provide affinity for hooks if needed
 hooks:


### PR DESCRIPTION
Fixes #72 

## Description

- add hpa support for web and worker deployments
- autoscale the pods when average CPU utilisation is above 75%
- set default Redis replica count to `1` from `3`

## Type of change
 
- [x] feature: add support for horizontal pod autoscaling

## How Has This Been Tested?

- [x]  Tested installation against a fresh k8s cluster
- [x]  Tested upgrade against a k8s cluster running Chatwoot v2.7.0

## Checklist:
 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the docs 
﻿
﻿
﻿
