### PR TITLE
Feature: allow an already existing secret to define env vars

### DIFF
--- a/charts/chatwoot/README.md
+++ b/charts/chatwoot/README.md
@@ -161,6 +161,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| existingEnvSecret | string | "" |  |
 | fullnameOverride | string | `""` |  |
 | hooks.affinity | object | `{}` |  |
 | hooks.migrate.env | list | `[]` |  |

--- a/charts/chatwoot/templates/web-deployment.yaml
+++ b/charts/chatwoot/templates/web-deployment.yaml
@@ -63,6 +63,10 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ template "chatwoot.fullname" . }}-env
+          {{- if .Values.existingEnvSecret }}
+            - secretRef:
+                name: {{ .Values.existingEnvSecret }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           name: {{ .Chart.Name }}-web
           ports:

--- a/charts/chatwoot/templates/worker-deployment.yaml
+++ b/charts/chatwoot/templates/worker-deployment.yaml
@@ -58,6 +58,10 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ template "chatwoot.fullname" . }}-env
+          {{- if .Values.existingEnvSecret }}
+            - secretRef:
+                name: {{ .Values.existingEnvSecret }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           name: {{ .Chart.Name }}-workers
           {{- with .Values.resources }}

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -160,6 +160,10 @@ hooks:
     hookAnnotation: "post-install,post-upgrade"
 
 # ENVIRONMENT VARIABLES
+
+# If set, will apply environment variables found in this secret, after the variables defined in the env key.
+existingEnvSecret: ""
+
 env:
   ACTIVE_STORAGE_SERVICE: local
   ANDROID_BUNDLE_ID: com.chatwoot.app


### PR DESCRIPTION
Thanks for the great work on this chart!

We have a desire to use an already defined `Secret` resource for setting sensitive environment variable values within our chatwoot deployment. Since we commit our helm values yaml files to a private git repository, we would prefer to use our already existing `Secret` management process that lets us define sensitive values "out of band" from the repository itself and reference them as an already existing secret.

In the current chart configuration, this isn't possible, and would mean we'd have to commit sensitive values to our repository. With this PR, the existing `Secret` resource would be used to pull in environment variables, and since it's referenced after the `Secret` created by the chart, it would simply add or override existing values there.

Of course, totally open to suggestions on how this could be done differently, or if you would prefer a different name to use for the new helm value parameter.