### PR TITLE
render security context

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -33,6 +33,5 @@ sources:
 # This is the chart version.
 version: 1.0.9
 
-
 # This is the application version.
 appVersion: "v2.10.0"

--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 1.0.5
+version: 1.0.7
 
 # This is the application version.
 appVersion: "v2.9.1"

--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 1.0.8
+version: 1.0.9
 
 
 # This is the application version.

--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -77,7 +77,9 @@ spec:
             - name: cache
               mountPath: /app/tmp
       serviceAccountName: {{ include "chatwoot.serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      {{- end }}
       volumes:
         - name: cache
           emptyDir: {}

--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -73,4 +73,11 @@ spec:
               name: {{ .Values.existingEnvSecret }}
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        volumeMounts:
+            - name: cache
+              mountPath: /app/tmp
       serviceAccountName: {{ include "chatwoot.serviceAccountName" . }}
+      securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      volumes:
+        - name: cache
+          emptyDir: {}

--- a/charts/chatwoot/templates/web-deployment.yaml
+++ b/charts/chatwoot/templates/web-deployment.yaml
@@ -76,5 +76,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          volumeMounts:
+            - name: cache
+              mountPath: /app/tmp
       serviceAccountName: {{ include "chatwoot.serviceAccountName" . }}
+      securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      volumes:
+        - name: cache
+          emptyDir: {}
+      
 status: {}

--- a/charts/chatwoot/templates/web-deployment.yaml
+++ b/charts/chatwoot/templates/web-deployment.yaml
@@ -80,7 +80,9 @@ spec:
             - name: cache
               mountPath: /app/tmp
       serviceAccountName: {{ include "chatwoot.serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      {{- end }}
       volumes:
         - name: cache
           emptyDir: {}

--- a/charts/chatwoot/templates/worker-deployment.yaml
+++ b/charts/chatwoot/templates/worker-deployment.yaml
@@ -73,7 +73,10 @@ spec:
             - name: cache
               mountPath: /app/tmp
       serviceAccountName: {{ include "chatwoot.serviceAccountName" . }}
+      {{- if .Values.securityContext }}
       securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      {{- end }}
       volumes:
         - name: cache
           emptyDir: {}
+

--- a/charts/chatwoot/templates/worker-deployment.yaml
+++ b/charts/chatwoot/templates/worker-deployment.yaml
@@ -69,6 +69,13 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: cache
+              mountPath: /app/tmp
       serviceAccountName: {{ include "chatwoot.serviceAccountName" . }}
+      securityContext: {{ .Values.securityContext | toYaml | nindent 8 }}
+      volumes:
+        - name: cache
+          emptyDir: {}
 
 status: {}


### PR DESCRIPTION
The chart has `securityContext` in the `vaules.yaml` file. However, this is misleading as this value is used nowhere in the chart.

This PR sets up all that's necessary to run chatwoot with a non-root user by:
- rendering  `securityContext` in migrate job and deployments
- setting up a temporary volume for cache. The container runs `mkdir` on a temporary folder, and for non-root to work, the folder has to be owned by running user