### PR TITLE
fix existingSecret for postgres

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 1.0.5
+version: 1.0.6
 
 # This is the application version.
 appVersion: "v2.9.1"

--- a/charts/chatwoot/templates/env-secret.yaml
+++ b/charts/chatwoot/templates/env-secret.yaml
@@ -11,7 +11,7 @@ data:
   POSTGRES_HOST: {{ include "chatwoot.postgresql.host" . | b64enc | quote }}
   POSTGRES_PORT: {{ include "chatwoot.postgresql.port" . | b64enc | quote }}
   POSTGRES_USERNAME: {{ default "postgres" .Values.postgresql.auth.username | b64enc | quote }}
-  {{- if not .Values.postgresql.existingSecret }}
+  {{- if not .Values.postgresql.auth.existingSecret }}
   POSTGRES_PASSWORD: {{ default "postgres" .Values.postgresql.auth.postgresPassword | b64enc | quote }}
   {{- end }}
   POSTGRES_DATABASE: {{ default "chatwoot_production" .Values.postgresql.auth.database | b64enc | quote }}

--- a/charts/chatwoot/templates/web-deployment.yaml
+++ b/charts/chatwoot/templates/web-deployment.yaml
@@ -46,12 +46,12 @@ spec:
           command:
             - docker/entrypoints/rails.sh
           env:
-          {{- if .Values.postgresql.existingSecret }}
+          {{- if .Values.postgresql.auth.existingSecret }}
           - name: POSTGRES_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.postgresql.existingSecret }}
-                key: {{ default "password" .Values.postgresql.existingSecretKey }}
+                name: {{ .Values.postgresql.auth.existingSecret }}
+                key: {{ default "password" .Values.postgresql.auth.existingSecretKey }}
           {{- end }}
           {{- if .Values.redis.existingSecret }}
           - name: REDIS_PASSWORD

--- a/charts/chatwoot/templates/worker-deployment.yaml
+++ b/charts/chatwoot/templates/worker-deployment.yaml
@@ -41,12 +41,12 @@ spec:
             - -C
             - config/sidekiq.yml
           env:
-          {{- if .Values.postgresql.existingSecret }}
+          {{- if .Values.postgresql.auth.existingSecret }}
           - name: POSTGRES_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.postgresql.existingSecret }}
-                key: {{ default "password" .Values.postgresql.existingSecretKey }}
+                name: {{ .Values.postgresql.auth.existingSecret }}
+                key: {{ default "password" .Values.postgresql.auth.existingSecretKey }}
           {{- end }}
           {{- if .Values.redis.existingSecret }}
           - name: REDIS_PASSWORD


### PR DESCRIPTION
The `values.yaml` file suggests that when using an existing secret for postgres secret, this should be specified as `postgresql.auth.existingSecret`. Indeed, this is how the secret is mounted in the migration job.

However, this is inconsistent with how the secret is mounted in Deployments and in the secret environment resource.

This PR makes the use of existingSecret consistent