### PR TITLE
Fix the existing postgres secret keys and allow for setting independent resources

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 1.0.7
+version: 1.0.8
 
 # This is the application version.
 appVersion: "v2.10.0"

--- a/charts/chatwoot/templates/web-deployment.yaml
+++ b/charts/chatwoot/templates/web-deployment.yaml
@@ -51,7 +51,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.postgresql.auth.existingSecret }}
-                key: {{ default "password" .Values.postgresql.auth.existingSecretKey }}
+                key: {{ default "password" .Values.postgresql.auth.secretKeys.adminPasswordKey }}
           {{- end }}
           {{- if .Values.redis.existingSecret }}
           - name: REDIS_PASSWORD

--- a/charts/chatwoot/templates/web-deployment.yaml
+++ b/charts/chatwoot/templates/web-deployment.yaml
@@ -72,9 +72,8 @@ spec:
           ports:
             - containerPort: {{ int .Values.services.internalPort }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.resources }}
+          {{- with .Values.web.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
             {{- end }}
       serviceAccountName: {{ include "chatwoot.serviceAccountName" . }}
-status: {}

--- a/charts/chatwoot/templates/worker-deployment.yaml
+++ b/charts/chatwoot/templates/worker-deployment.yaml
@@ -64,11 +64,9 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           name: {{ .Chart.Name }}-workers
-          {{- with .Values.resources }}
+          {{- with .Values.worker.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
       serviceAccountName: {{ include "chatwoot.serviceAccountName" . }}
-
-status: {}

--- a/charts/chatwoot/templates/worker-deployment.yaml
+++ b/charts/chatwoot/templates/worker-deployment.yaml
@@ -46,7 +46,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.postgresql.auth.existingSecret }}
-                key: {{ default "password" .Values.postgresql.auth.existingSecretKey }}
+                key: {{ default "password" .Values.postgresql.auth.secretKeys.adminPasswordKey }}
           {{- end }}
           {{- if .Values.redis.existingSecret }}
           - name: REDIS_PASSWORD

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -16,6 +16,17 @@ web:
     minpods: 1
     maxpods: 10
   replicaCount: 1
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 250m
+    #   memory: 256Mi
 worker:
   hpa:
     # set this to true to enable horizontal pod autoscaling
@@ -25,6 +36,17 @@ worker:
     minpods: 2
     maxpods: 10
   replicaCount: 2
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 250m
+    #   memory: 256Mi
 
 services:
   name: chatwoot
@@ -89,18 +111,6 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 500m
-  #   memory: 512Mi
-  # requests:
-  #   cpu: 250m
-  #   memory: 256Mi
 
 nodeSelector: {}
 

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -118,9 +118,9 @@ postgresql:
     # when existingSecret is defined auth.password, auth.PostgressPassword
     # is ignored.
     # existingSecret: secret-name
-    #    secretKeys:
-    #      adminPasswordKey: postgres-password
-    #      replicationPasswordKey: replication-password
+    # secretKeys:
+    #   adminPasswordKey: postgres-password
+    #   replicationPasswordKey: replication-password
   # The following variables are only used when internal PG is disabled
   # postgresqlHost: postgres
   # postgresqlPort: 5432


### PR DESCRIPTION
Recently the location of the existing secret and key location has changed. However, while the migration job did get this change the worker and web deployments were still referencing the old location of the postgres secret key. This PR fixes that. It also allows for specifying the resources for the web and workers independently, since without the having them auto-scale properly is not possible.