### PR TITLE
feat: upgrade charts to chatwoot v2.14.0

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 1.0.14
+version: 1.0.15
 
 # This is the application version.
-appVersion: "v2.13.1"
+appVersion: "v2.14.0"

--- a/charts/chatwoot/README.md
+++ b/charts/chatwoot/README.md
@@ -49,7 +49,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                | Description                                          | Value                 |
 | ------------------- | ---------------------------------------------------- | --------------------- |
 | `image.repository`  | Chatwoot image repository                           | `chatwoot/chatwoot`    |
-| `image.tag`         | Chatwoot image tag (immutable tags are recommended) | `v2.13.1`              |
+| `image.tag`         | Chatwoot image tag (immutable tags are recommended) | `v2.14.0`              |
 | `image.pullPolicy`  | Chatwoot image pull policy                          | `IfNotPresent`         |
 
  

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -4,7 +4,7 @@
 # Overrides the image tag whose default is the chart appVersion.
 image:
   repository: chatwoot/chatwoot
-  tag: v2.13.1
+  tag: v2.14.0
   pullPolicy: IfNotPresent
 
 web:


### PR DESCRIPTION
## Description

- Update charts to chatwoot v2.14.0
- https://github.com/chatwoot/chatwoot/releases/tag/v2.14.0

## Type of change
 
- [x] Chore (Update Chatwoot version)

## How Has This Been Tested?

- [x]  Tested installation against a fresh k8s cluster
- [x]  Tested upgrade against a k8s cluster running Chatwoot v2.13.1

## Checklist:
 
- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code



