### PR TITLE
Support podAnnotations for web and worker deployments

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 1.0.16
+version: 1.0.17
 
 # This is the application version.
 appVersion: "v2.15.0"

--- a/charts/chatwoot/templates/web-deployment.yaml
+++ b/charts/chatwoot/templates/web-deployment.yaml
@@ -25,6 +25,9 @@ spec:
         role: web
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/env-secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.tolerations }}
       tolerations:
@@ -34,7 +37,7 @@ spec:
       nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
       {{- end }}
       containers:
-        - args: 
+        - args:
             - bundle
             - exec
             - rails

--- a/charts/chatwoot/templates/worker-deployment.yaml
+++ b/charts/chatwoot/templates/worker-deployment.yaml
@@ -25,6 +25,9 @@ spec:
         role: worker
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/env-secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.tolerations }}
       tolerations:


### PR DESCRIPTION
Allows the user to specify custom pod annotations for the `web` and `worker` deployments. This is useful for things like `linkerd` injection, or whatever else the user might need.

I didn't add this to the migrations `Job` spec, not sure if it makes sense there. Could always use another `values.yaml` key if desired.