### PR TITLE
chore: upgrade charts to chatwoot v3.0.0

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,7 +31,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 1.1.0
+version: 1.1.1
 
 # This is the application version.
-appVersion: "v2.18.0"
+appVersion: "v3.0.0"

--- a/charts/chatwoot/README.md
+++ b/charts/chatwoot/README.md
@@ -49,7 +49,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                | Description                                          | Value                 |
 | ------------------- | ---------------------------------------------------- | --------------------- |
 | `image.repository`  | Chatwoot image repository                           | `chatwoot/chatwoot`    |
-| `image.tag`         | Chatwoot image tag (immutable tags are recommended) | `v2.18.0`              |
+| `image.tag`         | Chatwoot image tag (immutable tags are recommended) | `v3.0.0`               |
 | `image.pullPolicy`  | Chatwoot image pull policy                          | `IfNotPresent`         |
 
 

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -4,7 +4,7 @@
 # Overrides the image tag whose default is the chart appVersion.
 image:
   repository: chatwoot/chatwoot
-  tag: v2.18.0
+  tag: v3.0.0
   pullPolicy: IfNotPresent
 
 # Set to autoscaling/v2beta2 for older versions of kubernetes that do not have autoscaling/v2 API (pre v1.26)


### PR DESCRIPTION
## Description

- Update charts to chatwoot v3.0.0
- https://github.com/chatwoot/chatwoot/releases/tag/v3.0.0

## Type of change
 
- [x] Chore (Update Chatwoot version)

## How Has This Been Tested?

- [x]  Tested installation against a fresh k8s cluster
- [x]  Tested upgrade against a k8s cluster running Chatwoot v3.0.0

## Checklist:
 
- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code





