### PR TITLE
feature: Add Image Pull Secrets for CronJob InitContainers

### DIFF
--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -16,6 +16,10 @@ metadata:
 spec:
   template:
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       restartPolicy: Never
       {{- with .Values.tolerations }}
       tolerations:


### PR DESCRIPTION
To use an internalized image from a private repository, I noticed the `ImagePullSecrets` were missing for the InitContainers in the CronJob. This update includes the `ImagePullSecrets` configuration, enabling easier access to private images in custom deployments.