### PR TITLE
fix: Fixes 137 missing imagePullSecrets in migration-job

### DIFF
--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -16,6 +16,10 @@ metadata:
 spec:
   template:
     spec:
+	  {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+	    {{- toYaml . | nindent 6 }}
+	   {{- end }}
       restartPolicy: Never
       {{- with .Values.tolerations }}
       tolerations:


### PR DESCRIPTION
Hi team, I've implemented a fix for #137 which seemed straightforward enough. Please let me know if this works and if there's any changes.

Job spec before fix:
<img width="1213" alt="Screenshot 2024-11-16 at 12 40 25 AM" src="https://github.com/user-attachments/assets/f816c0ce-0343-4902-9cd4-f5bbb8808301">


Job spec after fix:
<img width="1213" alt="Screenshot 2024-11-16 at 12 41 03 AM" src="https://github.com/user-attachments/assets/83fbabe0-f15f-49a2-be50-7747ca86c88b">
