### PR TITLE
Support custom global.imageRegistry in migration job

### DIFF
--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -39,7 +39,7 @@ spec:
             done;
             echo "Database ready to accept connections."  ;
       - name: init-redis
-        image: busybox:1.28
+        image: "{{.Values.global.imageRegistry}}busybox:1.28"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["sh", "-c", "until nslookup {{ template "chatwoot.redis.host" . }} ; do echo waiting for {{ template "chatwoot.redis.host" . }} ; sleep 2; done;"]
       containers:


### PR DESCRIPTION
There is a common standard to prefix dockerhub images with global.imageRegistry variable in case someone does not want/can not use dockerhub. Example: https://github.com/elastic/helm-charts/issues/720

All dependent charts (postgres/redis) support this variable, chatwoot has an option as well, but busybox image is hardcoded for dockerhub. This change allows to use global.imageRegistry here as well