### PR TITLE
chore: fix python version in gh action

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.13
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0


### PR DESCRIPTION
- Linting gh action for charts repo was broken due to the old Python version. Update it to `3.13`