### PR TITLE
feat: replace postgres image with pgvector support

### DIFF
--- a/charts/chatwoot/values.v4-upgrade.yaml
+++ b/charts/chatwoot/values.v4-upgrade.yaml
@@ -1,0 +1,9 @@
+image:
+  repository: chatwoot/chatwoot
+  tag: v4.0.1
+  pullPolicy: IfNotPresent
+
+postgresql:
+  image:
+    registry: ghcr.io
+    repository: chatwoot/pgvector

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -126,6 +126,9 @@ affinity: {}
 postgresql:
   enabled: true
   nameOverride: chatwoot-postgresql
+  image:
+    registry: ghcr.io
+    repository: chatwoot/pgvector
   auth:
     username: postgres
     postgresPassword: postgres


### PR DESCRIPTION
Chatwoot v4 and above requires PostgreSQL with pgvector support. Replace the default Bitnami PostgreSQL image with a custom image that has `pgvector` installed.

This only affects users relying on postgres installed via charts.

ref: https://chwt.app/v4/migration