### PR TITLE
fix: add missing resource injection for db-migrate-job 

### DIFF
--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -49,6 +49,10 @@ spec:
       containers:
       - name: "db-migrate-job"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- with .Values.hooks.migrate.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         args:
         - bundle
         - exec


### PR DESCRIPTION
# Summary
This PR finishes implementing the already intended behavior of specifying resources for the migration Job via hooks.migrate.resources. While the values.yaml contained a hooks.migrate.resources key, it was never actually injected into the migration template—so specifying resources there had no effect. This update properly references the user-defined resource values in migrations-job.yaml.

# Why
- The chart hinted that you could configure resources for the migration hook, but it wasn’t functional.

- Some Kubernetes environments require explicit resource requests/limits for all workloads, including Jobs, or they won’t schedule properly.

# What Changed
- migrations-job.yaml: Added a {{- with .Values.hooks.migrate.resources }} block in the db-migrate-job container so that resource settings are included only if configured.
- Ensures backward compatibility by omitting the resources: stanza when no values are provided.

# Testing
- Ran helm template locally with and without hooks.migrate.resources set to confirm correct rendering of the resources: block.

