### PR TITLE
Fix pg_isready for migration_job

### DIFF
--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -36,7 +36,7 @@ spec:
         args:
           - -c
           - >-
-            PG_READY="pg_isready -h {{ template "chatwoot.postgresql.host" . }} -p {{ template "chatwoot.postgresql.port" . }}";
+            PG_READY="pg_isready -h {{ template "chatwoot.postgresql.host" . }} -p {{ template "chatwoot.postgresql.port" . }} -U {{ .Values.postgresql.auth.username }}";
             until $PG_READY;
             do
               sleep 2;


### PR DESCRIPTION
Description
After setting up chatwoot today, my instance was not able to start. I am using the built-in bitnami postgrsql db.
As it turned out, the db initialization (migration job) was stuck, because the pg_isready command in the init container didn't succeed. It just printed out no attempt, which suggests an invalid configuration (see https://www.postgresql.org/docs/current/app-pg-isready.html).

Solution
After adding the -U postgres parameter manually, the command exited with 0 and the migrations where able to run

Same issue in another pull request #156 