### PR TITLE
feat: upgrade charts to chatwoot v4.4.0

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -31,8 +31,8 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 2.0.3
+version: 2.0.4
 
 
 # This is the application version.
-appVersion: "v4.3.0"
+appVersion: "v4.4.0"

--- a/charts/chatwoot/README.md
+++ b/charts/chatwoot/README.md
@@ -49,7 +49,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                | Description                                          | Value                 |
 | ------------------- | ---------------------------------------------------- | --------------------- |
 | `image.repository`  | Chatwoot image repository                           | `chatwoot/chatwoot`    |
-| `image.tag`         | Chatwoot image tag (immutable tags are recommended) | `v4.3.0`              |
+| `image.tag`         | Chatwoot image tag (immutable tags are recommended) | `v4.4.0`              |
 | `image.pullPolicy`  | Chatwoot image pull policy                          | `IfNotPresent`         |
 
 

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -4,7 +4,7 @@
 # Overrides the image tag whose default is the chart appVersion.
 image:
   repository: chatwoot/chatwoot
-  tag: v4.3.0
+  tag: v4.4.0
   pullPolicy: IfNotPresent
 
 # Set to autoscaling/v2beta2 for older versions of kubernetes that do not have autoscaling/v2 API (pre v1.26)


### PR DESCRIPTION
### Description

- Update charts to chatwoot v4.4.0
- Please read the migration guide before upgrading to v4 from 3.x.x
- https://chwt.app/v4/migration
- https://github.com/chatwoot/chatwoot/releases/tag/v4.4.0

### Type of change

- [x]  Chore (Update Chatwoot version)

### How Has This Been Tested?

- [x]  Tested installation against a fresh k8s cluster
- [x]  Tested upgrade against a k8s cluster running Chatwoot v4.3.0

### Checklist:

- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my code