### PR TITLE
fix: use chatwoot image for redis init container

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -34,7 +34,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 2.0.18
+version: 2.0.19
 
 
 # This is the application version.

--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -43,7 +43,7 @@ spec:
             done;
             echo "Database ready to accept connections."  ;
       - name: init-redis
-        image: busybox:1.28
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["sh", "-c", "until nslookup {{ template "chatwoot.redis.host" . }} ; do echo waiting for {{ template "chatwoot.redis.host" . }} ; sleep 2; done;"]
       containers:


### PR DESCRIPTION
## Summary
- Replace `busybox:1.28` with the chatwoot app image for the redis init container in `migrations-job.yaml`
- The chatwoot image already has `nslookup` and is already being pulled for the main container, so no extra image download
- Fixes image pull policy issues for orgs that block external images
- Bump chart version to 2.0.19