### PR TITLE
fix: use getent instead of nslookup for redis readiness check

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -34,7 +34,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 2.0.19
+version: 2.0.20
 
 
 # This is the application version.

--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -45,7 +45,7 @@ spec:
       - name: init-redis
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["sh", "-c", "until nslookup {{ template "chatwoot.redis.host" . }} ; do echo waiting for {{ template "chatwoot.redis.host" . }} ; sleep 2; done;"]
+        command: ["sh", "-c", "until getent hosts {{ template "chatwoot.redis.host" . }} ; do echo waiting for {{ template "chatwoot.redis.host" . }} ; sleep 2; done;"]
       containers:
       - name: "db-migrate-job"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
## Summary

Fixes #200
Fixes https://linear.app/chatwoot/issue/INF-65

The `init-redis` init container in the migration job hangs indefinitely on upgrade to 2.0.19. The root cause is that `nslookup` in BusyBox v1.37+ (shipped in the chatwoot app image) exits 1 when intermediate search domain lookups return NXDOMAIN, even when the final lookup succeeds. Combined with Kubernetes' default `ndots:5`, the `until` loop never exits.

This replaces `nslookup` with `getent hosts`, which uses the system C library resolver. It returns the first successful result and exits 0 regardless of search domain behavior.

## Why not the other suggested fixes?

- **Revert to `busybox:1.28`**: This was changed intentionally in 2.0.19 (for INF-61) because orgs with strict image pull policies block external images like busybox. Reverting reintroduces that problem.
- **FQDN with `.Release.Namespace.svc.cluster.local`**: Only works for bundled Redis. The `chatwoot.redis.host` template can return an external hostname when `redis.enabled=false`, and appending `.namespace.svc.cluster.local` to that would break resolution.
- **`getent hosts`**: Works for both bundled and external Redis. Uses the same resolver path as every other application in the container. Available in the chatwoot image (confirmed).

## Test Plan
 - [ ] Deploy  both 2.0.19 (broken) and the fix to separate namespaces on a test cluster