### PR TITLE
fix: make health probes configurable with better defaults

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -34,7 +34,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 2.0.20
+version: 2.0.21
 
 
 # This is the application version.

--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -34,7 +34,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 2.0.19
+version: 2.0.20
 
 
 # This is the application version.

--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -45,7 +45,7 @@ spec:
       - name: init-redis
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["sh", "-c", "until nslookup {{ template "chatwoot.redis.host" . }} ; do echo waiting for {{ template "chatwoot.redis.host" . }} ; sleep 2; done;"]
+        command: ["sh", "-c", "until getent hosts {{ template "chatwoot.redis.host" . }} ; do echo waiting for {{ template "chatwoot.redis.host" . }} ; sleep 2; done;"]
       containers:
       - name: "db-migrate-job"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/chatwoot/templates/web-deployment.yaml
+++ b/charts/chatwoot/templates/web-deployment.yaml
@@ -87,21 +87,17 @@ spec:
             httpGet:
               path: /health
               port: {{ int .Values.services.internalPort }}
-            initialDelaySeconds: 15
-            periodSeconds: 15
+            {{- toYaml .Values.web.livenessProbe | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /api
               port: {{ int .Values.services.internalPort }}
-            initialDelaySeconds: 15
-            periodSeconds: 5
+            {{- toYaml .Values.web.readinessProbe | nindent 12 }}
           startupProbe:
             httpGet:
               path: /health
               port: {{ int .Values.services.internalPort }}
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            failureThreshold: 30
+            {{- toYaml .Values.web.startupProbe | nindent 12 }}
           volumeMounts:
             - name: cache
               mountPath: /app/tmp

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -22,6 +22,21 @@ web:
     minpods: 1
     maxpods: 10
   replicaCount: 1
+  livenessProbe:
+    initialDelaySeconds: 15
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    initialDelaySeconds: 15
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 3
+  startupProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 60
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## Summary
- Add `timeoutSeconds: 5` to liveness, readiness, and startup probes (was defaulting to K8s implicit 1s)
- Increase startup probe `failureThreshold` from 30 to 60 (~10 min budget instead of ~5.5 min)
- Move probe configuration to `values.yaml` so self-hosted customers can tune without forking the chart

## Context
Self-hosted customer reported pods stuck in restart loops due to health check failures. Root cause was CPU-starved pods taking too long to boot Rails, combined with the implicit 1s `timeoutSeconds` killing pods that were slow to respond after startup.

## Test plan
- [x] `helm template` renders probes correctly with default values
- [x] Verify existing deployments are not affected (defaults are strictly more permissive)
- [x] Verify customers can override probe values via values.yaml