### PR TITLE
Support for external Redis/Valkey with ACL / RBAC username and logical DB

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -34,7 +34,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 2.0.21
+version: 2.0.22
 
 
 # This is the application version.

--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -34,7 +34,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 2.0.22
+version: 2.0.23
 
 
 # This is the application version.

--- a/charts/chatwoot/README.md
+++ b/charts/chatwoot/README.md
@@ -106,8 +106,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                                | Description                                                                | Default Value                                       |
 | ----------------------------------- | -------------------------------------------------------------------------  | --------------------------------------------------- |
 | `redis.enabled`                     | Set to `false` if using external redis and modify the below variables.     | `true`                                              |
-| `redis.auth.password`               | Password used for internal redis cluster                                   | `redis`                                             |
+| `redis.auth.password`               | Password for the **bundled** Bitnami Redis subchart (`redis.enabled=true` only). | `redis`                                             |
 | `env.REDIS_TLS`                     | Set to `true` if TLS(`rediss://`) is required                              | `false`                                             |
+
+`redis.auth` is consumed by the embedded Redis chart. For **external** Redis, use `redis.host`, `redis.port`, `redis.password`, and optionally `redis.username` / `redis.database` below.
 
 #### External Redis (when `redis.enabled=false`)
 
@@ -115,7 +117,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------- | -------------------------------------------------------------------------  | --------------------------------------------------- |
 | `redis.host`                        | Redis host name                                                            | `""`                                                |
 | `redis.port`                        | Redis port                                                                 | `""`                                                |
-| `redis.password`                    | Redis password                                                             | `""`                                                |
+| `redis.password`                    | Redis password (stored in `REDIS_PASSWORD`; not embedded in `REDIS_URL`).   | `""`                                                |
+| `redis.username`                    | Optional. Redis 6+ ACL / Valkey RBAC username. When set, `REDIS_URL` is `scheme://username@host:port` and the password stays only in `REDIS_PASSWORD` (see Chatwoot `Redis::Config`). | `""`                                                |
+| `redis.database`                    | Optional logical DB index appended to `REDIS_URL` as `.../{index}` (e.g. `0` or `"0"` for the default DB). | `""`                                                |
 | `env.REDIS_SENTINELS`               | Comma-separated list of sentinel host:port pairs (e.g. `sentinel-0:26379,sentinel-1:26379`) | `""`                                  |
 | `env.REDIS_SENTINEL_MASTER_NAME`    | Sentinel master name                                                       | `""`                                                |
 

--- a/charts/chatwoot/README.md
+++ b/charts/chatwoot/README.md
@@ -117,9 +117,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------- | -------------------------------------------------------------------------  | --------------------------------------------------- |
 | `redis.host`                        | Redis host name                                                            | `""`                                                |
 | `redis.port`                        | Redis port                                                                 | `""`                                                |
-| `redis.password`                    | Redis password (stored in `REDIS_PASSWORD`; not embedded in `REDIS_URL`).   | `""`                                                |
-| `redis.username`                    | Optional. Redis 6+ ACL / Valkey RBAC username. When set, `REDIS_URL` is `scheme://username@host:port` and the password stays only in `REDIS_PASSWORD` (see Chatwoot `Redis::Config`). | `""`                                                |
+| `redis.password`                    | Redis password. With ACL + `aclEmbedPasswordInUrl` (default), embedded in `REDIS_URL` only; otherwise stored in `REDIS_PASSWORD`. | `""`                                                |
+| `redis.username`                    | Optional. Redis 6+ ACL / Valkey RBAC username. See `aclEmbedPasswordInUrl`. | `""`                                                |
 | `redis.database`                    | Optional logical DB index appended to `REDIS_URL` as `.../{index}` (e.g. `0` or `"0"` for the default DB). | `""`                                                |
+| `redis.aclEmbedPasswordInUrl`       | If `true` (default) and `redis.username` is set and `redis.existingSecret` is empty, `REDIS_URL` is `scheme://user:pass@host…` (password URL-encoded); `REDIS_PASSWORD` is omitted from the env Secret. | `true`                                              |
 | `env.REDIS_SENTINELS`               | Comma-separated list of sentinel host:port pairs (e.g. `sentinel-0:26379,sentinel-1:26379`) | `""`                                  |
 | `env.REDIS_SENTINEL_MASTER_NAME`    | Sentinel master name                                                       | `""`                                                |
 

--- a/charts/chatwoot/templates/_helpers.tpl
+++ b/charts/chatwoot/templates/_helpers.tpl
@@ -215,16 +215,29 @@ Set redis sentinel master name
 {{- end -}}
 
 {{/*
+Whether to emit REDIS_PASSWORD in the generated env Secret (external Redis without redis.existingSecret).
+Omit when ACL embed mode: password is only inside REDIS_URL (avoids duplicate AUTH with redis-client/TLS+ACL).
+*/}}
+{{- define "chatwoot.redis.shouldEmitRedisPasswordKey" -}}
+{{- if .Values.redis.enabled -}}
+true
+{{- else if and (ne (trim (default "" .Values.redis.username)) "") .Values.redis.aclEmbedPasswordInUrl -}}
+false
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
 Set redis URL
 
-External Redis (redis.enabled=false): Chatwoot passes REDIS_URL and REDIS_PASSWORD separately
-(see lib/redis/config.rb); redis-rb authenticates with the ACL user from the URL and password from env.
-Do not embed the password in REDIS_URL — placeholders like $(REDIS_PASSWORD) are not expanded by Chatwoot.
+External Redis (redis.enabled=false):
+- Default user: scheme://host:port + REDIS_PASSWORD in Secret.
+- ACL (redis.username): if aclEmbedPasswordInUrl and password is available to Helm (no redis.existingSecret),
+  scheme://username:urlencoded-password@host:port/db — REDIS_PASSWORD omitted from Secret.
+  If redis.existingSecret is set, password cannot be templated into URL; use user@host + REDIS_PASSWORD via deployment env ref.
 
-- No ACL username: scheme://host:port (password from REDIS_PASSWORD only).
-- ACL / Valkey RBAC: set redis.username (external Redis only; not redis.auth, which is for bundled Bitnami Redis).
-
-Optional redis.database appends /{db} (e.g. 0 or "0"). Uses string form so index 0 is not treated as empty.
+Password components are url-encoded (urlquery) for safe inclusion in the URI userinfo.
 */}}
 {{- define "chatwoot.redis.externalDatabaseSuffix" -}}
 {{- $d := .Values.redis.database | toString | trim -}}
@@ -243,7 +256,11 @@ redis://:{{ .Values.redis.auth.password }}@{{ template "chatwoot.redis.host" . }
 {{- $port := include "chatwoot.redis.port" . | trim -}}
 {{- $user := default "" .Values.redis.username | trim -}}
 {{- $dbpath := include "chatwoot.redis.externalDatabaseSuffix" . -}}
-{{- if $user -}}
+{{- $embedAcl := and $user (not .Values.redis.existingSecret) .Values.redis.aclEmbedPasswordInUrl -}}
+{{- if and $user $embedAcl -}}
+{{- $pass := include "chatwoot.redis.password" . -}}
+{{- printf "%s://%s:%s@%s:%s%s" $scheme ($user | urlquery) ($pass | urlquery) $host $port $dbpath -}}
+{{- else if $user -}}
 {{- printf "%s://%s@%s:%s%s" $scheme $user $host $port $dbpath -}}
 {{- else if $tls -}}
 {{- printf "rediss://%s:%s%s" $host $port $dbpath -}}

--- a/charts/chatwoot/templates/_helpers.tpl
+++ b/charts/chatwoot/templates/_helpers.tpl
@@ -216,13 +216,39 @@ Set redis sentinel master name
 
 {{/*
 Set redis URL
+
+External Redis (redis.enabled=false): Chatwoot passes REDIS_URL and REDIS_PASSWORD separately
+(see lib/redis/config.rb); redis-rb authenticates with the ACL user from the URL and password from env.
+Do not embed the password in REDIS_URL — placeholders like $(REDIS_PASSWORD) are not expanded by Chatwoot.
+
+- No ACL username: scheme://host:port (password from REDIS_PASSWORD only).
+- ACL / Valkey RBAC: set redis.username (external Redis only; not redis.auth, which is for bundled Bitnami Redis).
+
+Optional redis.database appends /{db} (e.g. 0 or "0"). Uses string form so index 0 is not treated as empty.
 */}}
+{{- define "chatwoot.redis.externalDatabaseSuffix" -}}
+{{- $d := .Values.redis.database | toString | trim -}}
+{{- if and $d (ne $d "") (ne $d "<nil>") -}}
+{{- printf "/%s" $d -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "chatwoot.redis.url" -}}
 {{- if .Values.redis.enabled -}}
-    redis://:{{ .Values.redis.auth.password }}@{{ template "chatwoot.redis.host" . }}:{{ template "chatwoot.redis.port" . }}
-{{- else if .Values.env.REDIS_TLS -}}
-    rediss://:$(REDIS_PASSWORD)@{{ .Values.redis.host }}:{{ .Values.redis.port }}
+redis://:{{ .Values.redis.auth.password }}@{{ template "chatwoot.redis.host" . }}:{{ template "chatwoot.redis.port" . }}
 {{- else -}}
-    redis://:$(REDIS_PASSWORD)@{{ .Values.redis.host }}:{{ .Values.redis.port }}
+{{- $tls := .Values.env.REDIS_TLS -}}
+{{- $scheme := ternary "rediss" "redis" $tls -}}
+{{- $host := include "chatwoot.redis.host" . | trim -}}
+{{- $port := include "chatwoot.redis.port" . | trim -}}
+{{- $user := default "" .Values.redis.username | trim -}}
+{{- $dbpath := include "chatwoot.redis.externalDatabaseSuffix" . -}}
+{{- if $user -}}
+{{- printf "%s://%s@%s:%s%s" $scheme $user $host $port $dbpath -}}
+{{- else if $tls -}}
+{{- printf "rediss://%s:%s%s" $host $port $dbpath -}}
+{{- else -}}
+{{- printf "redis://%s:%s%s" $host $port $dbpath -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/chatwoot/templates/_helpers.tpl
+++ b/charts/chatwoot/templates/_helpers.tpl
@@ -230,7 +230,7 @@ false
 Set redis URL
 
 External: default user → scheme://host:port + REDIS_PASSWORD; ACL embed → user:pass in URL (see externalAclEmbedActive);
-existingSecret → user@host in URL + REDIS_PASSWORD from Deployment ref. Userinfo is url-encoded (urlquery).
+existingSecret / no embed → user@host in URL + REDIS_PASSWORD from Deployment ref. Username (and password when embedded) uses urlquery.
 */}}
 {{- define "chatwoot.redis.externalDatabaseSuffix" -}}
 {{- $d := .Values.redis.database | toString | trim -}}
@@ -253,7 +253,7 @@ redis://:{{ .Values.redis.auth.password }}@{{ template "chatwoot.redis.host" . }
 {{- $pass := include "chatwoot.redis.password" . -}}
 {{- printf "%s://%s:%s@%s:%s%s" $scheme ($user | urlquery) ($pass | urlquery) $host $port $dbpath -}}
 {{- else if $user -}}
-{{- printf "%s://%s@%s:%s%s" $scheme $user $host $port $dbpath -}}
+{{- printf "%s://%s@%s:%s%s" $scheme ($user | urlquery) $host $port $dbpath -}}
 {{- else if $tls -}}
 {{- printf "rediss://%s:%s%s" $host $port $dbpath -}}
 {{- else -}}

--- a/charts/chatwoot/templates/_helpers.tpl
+++ b/charts/chatwoot/templates/_helpers.tpl
@@ -215,29 +215,22 @@ Set redis sentinel master name
 {{- end -}}
 
 {{/*
-Whether to emit REDIS_PASSWORD in the generated env Secret (external Redis without redis.existingSecret).
-Omit when ACL embed mode: password is only inside REDIS_URL (avoids duplicate AUTH with redis-client/TLS+ACL).
+True when external Redis uses ACL with user+password embedded in REDIS_URL (Helm knows the password).
+Same condition drives chatwoot.redis.url and whether REDIS_PASSWORD is emitted in the env Secret (avoid duplicate AUTH).
 */}}
-{{- define "chatwoot.redis.shouldEmitRedisPasswordKey" -}}
-{{- if .Values.redis.enabled -}}
+{{- define "chatwoot.redis.externalAclEmbedActive" -}}
+{{- if and (not .Values.redis.enabled) (ne (trim (default "" .Values.redis.username)) "") (not .Values.redis.existingSecret) .Values.redis.aclEmbedPasswordInUrl -}}
 true
-{{- else if and (ne (trim (default "" .Values.redis.username)) "") .Values.redis.aclEmbedPasswordInUrl -}}
-false
 {{- else -}}
-true
+false
 {{- end -}}
 {{- end -}}
 
 {{/*
 Set redis URL
 
-External Redis (redis.enabled=false):
-- Default user: scheme://host:port + REDIS_PASSWORD in Secret.
-- ACL (redis.username): if aclEmbedPasswordInUrl and password is available to Helm (no redis.existingSecret),
-  scheme://username:urlencoded-password@host:port/db — REDIS_PASSWORD omitted from Secret.
-  If redis.existingSecret is set, password cannot be templated into URL; use user@host + REDIS_PASSWORD via deployment env ref.
-
-Password components are url-encoded (urlquery) for safe inclusion in the URI userinfo.
+External: default user → scheme://host:port + REDIS_PASSWORD; ACL embed → user:pass in URL (see externalAclEmbedActive);
+existingSecret → user@host in URL + REDIS_PASSWORD from Deployment ref. Userinfo is url-encoded (urlquery).
 */}}
 {{- define "chatwoot.redis.externalDatabaseSuffix" -}}
 {{- $d := .Values.redis.database | toString | trim -}}
@@ -256,8 +249,7 @@ redis://:{{ .Values.redis.auth.password }}@{{ template "chatwoot.redis.host" . }
 {{- $port := include "chatwoot.redis.port" . | trim -}}
 {{- $user := default "" .Values.redis.username | trim -}}
 {{- $dbpath := include "chatwoot.redis.externalDatabaseSuffix" . -}}
-{{- $embedAcl := and $user (not .Values.redis.existingSecret) .Values.redis.aclEmbedPasswordInUrl -}}
-{{- if and $user $embedAcl -}}
+{{- if eq (include "chatwoot.redis.externalAclEmbedActive" .) "true" -}}
 {{- $pass := include "chatwoot.redis.password" . -}}
 {{- printf "%s://%s:%s@%s:%s%s" $scheme ($user | urlquery) ($pass | urlquery) $host $port $dbpath -}}
 {{- else if $user -}}

--- a/charts/chatwoot/templates/additional-ingresses.yaml
+++ b/charts/chatwoot/templates/additional-ingresses.yaml
@@ -1,0 +1,53 @@
+{{- range $name, $ingress := .Values.additionalIngresses }}
+{{- if $ingress.enabled -}}
+{{- $fullName := printf "%s-%s" (include "chatwoot.fullname" $) $name -}}
+{{- $svcPort := $.Values.service.port -}}
+{{- if semverCompare ">=1.14-0" $.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "chatwoot.fullname" $ }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+  {{- with $ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and $ingress.ingressClassName (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ $ingress.ingressClassName }}
+  {{- end }}
+  {{- if $ingress.tls }}
+  tls:
+    {{- range $ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range $ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ .backend.service.name }}
+                port:
+                  number: {{ int .backend.service.port.number }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+---
+{{- end }}

--- a/charts/chatwoot/templates/env-secret.yaml
+++ b/charts/chatwoot/templates/env-secret.yaml
@@ -17,7 +17,7 @@ data:
   POSTGRES_DATABASE: {{ default "chatwoot_production" .Values.postgresql.auth.database | b64enc | quote }}
   REDIS_HOST: {{ include "chatwoot.redis.host" . | b64enc | quote }}
   REDIS_PORT: {{ include "chatwoot.redis.port" . | b64enc | quote }}
-  {{- if not .Values.redis.existingSecret }}
+  {{- if and (not .Values.redis.existingSecret) (eq (include "chatwoot.redis.shouldEmitRedisPasswordKey" .) "true") }}
   REDIS_PASSWORD: {{ include "chatwoot.redis.password" . | b64enc | quote }}
   {{- end }}
   REDIS_URL: {{ include "chatwoot.redis.url" . | b64enc | quote }}

--- a/charts/chatwoot/templates/env-secret.yaml
+++ b/charts/chatwoot/templates/env-secret.yaml
@@ -17,7 +17,7 @@ data:
   POSTGRES_DATABASE: {{ default "chatwoot_production" .Values.postgresql.auth.database | b64enc | quote }}
   REDIS_HOST: {{ include "chatwoot.redis.host" . | b64enc | quote }}
   REDIS_PORT: {{ include "chatwoot.redis.port" . | b64enc | quote }}
-  {{- if and (not .Values.redis.existingSecret) (eq (include "chatwoot.redis.shouldEmitRedisPasswordKey" .) "true") }}
+  {{- if and (not .Values.redis.existingSecret) (or .Values.redis.enabled (ne (include "chatwoot.redis.externalAclEmbedActive" .) "true")) }}
   REDIS_PASSWORD: {{ include "chatwoot.redis.password" . | b64enc | quote }}
   {{- end }}
   REDIS_URL: {{ include "chatwoot.redis.url" . | b64enc | quote }}

--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -62,7 +62,13 @@ spec:
               name: {{ .Values.postgresql.auth.existingSecret }}
               key: {{ default "password" .Values.postgresql.auth.secretKeys.adminPasswordKey }}
         {{- end }}
-        {{- if .Values.redis.auth.existingSecret }}
+        {{- if .Values.redis.existingSecret }}
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.redis.existingSecret }}
+              key: {{ default "password" .Values.redis.existingSecretKey }}
+        {{- else if and .Values.redis.enabled .Values.redis.auth.existingSecret }}
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -176,10 +176,14 @@ redis:
   # Just omit the password field if your redis cluster doesn't use password
   # password: redis
   # port: 6379
-  # Redis 6+ ACL / Valkey RBAC: non-default user (empty = default user). REDIS_URL: scheme://username@host:port; password only in REDIS_PASSWORD.
+  # Redis 6+ ACL / Valkey RBAC: non-default user (empty = default user).
   username: ""
   # Optional logical DB index in REDIS_URL (e.g. "0" -> .../0).
   database: ""
+  # External Redis + ACL (redis.username set): embed password inside REDIS_URL (scheme://user:pass@host…).
+  # Recommended for redis-rb/TLS+ACL; when true, REDIS_PASSWORD is omitted from the env Secret to avoid duplicate AUTH.
+  # If redis.existingSecret is set, Helm cannot embed the password in REDIS_URL; keep user@host in URL + REDIS_PASSWORD from the Secret ref.
+  aclEmbedPasswordInUrl: true
   sentinel:
     enabled: false
     # masterSet: mymaster

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -170,11 +170,16 @@ redis:
     # when defined the password field is ignored
     #    existingSecret: secret-name
     #    existingSecretPasswordKey: ""
-  # The following variables are only used when internal Redis is disabled
+  # --- External Redis only (when redis.enabled=false) ---
+  # redis.auth.* above is for the bundled Bitnami Redis; do not use it for external ACL/Valkey user.
   # host: redis
   # Just omit the password field if your redis cluster doesn't use password
   # password: redis
   # port: 6379
+  # Redis 6+ ACL / Valkey RBAC: non-default user (empty = default user). REDIS_URL: scheme://username@host:port; password only in REDIS_PASSWORD.
+  username: ""
+  # Optional logical DB index in REDIS_URL (e.g. "0" -> .../0).
+  database: ""
   sentinel:
     enabled: false
     # masterSet: mymaster

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -134,6 +134,8 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+additionalIngresses: {}
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## Summary

This PR adds first-class support for **external Redis/Valkey** in production-style clusters: **TLS** (`rediss`), **Redis 6+ ACL / RBAC username**, optional **logical DB** in `REDIS_URL`, and consistent **password handling** so it matches `redis-rb` and Chatwoot’s expectations.

## What we implemented

### External Redis / Valkey (ACL + TLS)

- **`REDIS_URL` generation** (`_helpers.tpl`): supports `rediss://` when `env.REDIS_TLS` is true; optional `redis.username` for ACL; optional `redis.database` as path suffix; URL-encoded user/password in the URI when credentials are embedded.
- **Single source of truth — `chatwoot.redis.externalAclEmbedActive`**: one helper is `true` only when external Redis uses ACL with **user + password embedded in `REDIS_URL`** (Helm knows the password, no `redis.existingSecret`, `redis.aclEmbedPasswordInUrl` enabled). The same condition drives:
  - the **`user:pass@host`** branch of `chatwoot.redis.url`, and  
  - whether **`REDIS_PASSWORD`** is written to the generated env Secret (omitted in embed mode to avoid **duplicate AUTH** with TLS+ACL clients).
- **`redis.aclEmbedPasswordInUrl`** (default `true`): when ACL username is set and the password is available to Helm, the password can live **only** in `REDIS_URL`. If **`redis.existingSecret`** is used, Helm cannot inline the password into `REDIS_URL`; the chart keeps **`user@host` in the URL** and **`REDIS_PASSWORD`** from the Deployment `secretKeyRef` (unchanged pattern).

### Env Secret

- **`REDIS_PASSWORD`** in the generated Secret is emitted when `not redis.existingSecret` and **`redis.enabled` OR external ACL embed is not active** — equivalent to omitting the key only in the external ACL-embed case described above.

### Documentation

- README updates for external Redis, ACL, TLS, and password/URL behavior.

## Why we need this

We run Chatwoot on **EKS** with **managed PostgreSQL** and **managed Valkey/ElastiCache** (TLS, ACL user, secrets from AWS Secrets Manager). The default chart path (bundled Bitnami Redis or a minimal `redis://` + separate password) is not enough for **TLS + ACL** without careful `REDIS_URL` and env composition. These changes make Helm predictable for that deployment model while preserving compatibility with bundled Redis/Postgres flows.