### PR TITLE
Feature: Allow configuring Helm hook weight via values

### DIFF
--- a/charts/chatwoot/Chart.yaml
+++ b/charts/chatwoot/Chart.yaml
@@ -34,7 +34,7 @@ sources:
   - http://www.chatwoot.com
 
 # This is the chart version.
-version: 2.0.23
+version: 2.0.24
 
 
 # This is the application version.

--- a/charts/chatwoot/templates/migrations-job.yaml
+++ b/charts/chatwoot/templates/migrations-job.yaml
@@ -12,7 +12,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": {{ .Values.hooks.migrate.hookAnnotation }}
     "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
-    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-weight": {{ .Values.hooks.migrate.hookWeight | quote }}
 spec:
   template:
     spec:

--- a/charts/chatwoot/values.yaml
+++ b/charts/chatwoot/values.yaml
@@ -201,6 +201,7 @@ hooks:
     # Defaults to performing the DB migration job after the install/upgrade.
     # Can be overridden to "pre-install,pre-upgrade" with caution to perform migrations that are sometimes required for the deployment to become healthy
     hookAnnotation: "post-install,post-upgrade"
+    hookWeight: -1
 
 # ENVIRONMENT VARIABLES
 


### PR DESCRIPTION
### Why is this needed

As written, the chart can't be installed by argo-cd. Argo-cd maps Helm hooks to its own hook system, translating hook-weight to sync-wave. Because of differences in execution timing, certain migration  jobs can enter a deadlock: the sync cannot succeed until the migration runs, but the migration isn't executed until the sync succeeds.

Making the hook weight configurable allows the migration to run after  resources are synced but before the overall sync finishes.

### Using this in argo-cd

Using the following values ensures that the hooks run before the start of the second sync wave (i.e sync wave 1)

```
source:
  helm:
    parameters:
      - name: hooks.migrate.hookAnnotation
        value: pre-install,pre-upgrade
      - name: hooks.migrate.hookWeight
        value: '1'
```